### PR TITLE
feat: add OpenTelemetry instrumentation (traces, logs, metrics)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,35 +5,77 @@
     "": {
       "name": "reji-cleaner",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/api-logs": "^0.218.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "^0.218.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.218.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.218.0",
+        "@opentelemetry/resources": "^2.7.1",
+        "@opentelemetry/sdk-logs": "^0.218.0",
+        "@opentelemetry/sdk-metrics": "^2.7.1",
+        "@opentelemetry/sdk-trace-node": "^2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.41.1",
         "@typescript/native-preview": "^7.0.0-dev.20250822.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.3.13",
+        "@biomejs/biome": "2.4.16",
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5.0.0",
+        "typescript": "^5.0.0 || ^6.0.0",
       },
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.3.13", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.13", "@biomejs/cli-darwin-x64": "2.3.13", "@biomejs/cli-linux-arm64": "2.3.13", "@biomejs/cli-linux-arm64-musl": "2.3.13", "@biomejs/cli-linux-x64": "2.3.13", "@biomejs/cli-linux-x64-musl": "2.3.13", "@biomejs/cli-win32-arm64": "2.3.13", "@biomejs/cli-win32-x64": "2.3.13" }, "bin": { "biome": "bin/biome" } }, "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.13", "", { "os": "linux", "cpu": "x64" }, "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.13", "", { "os": "linux", "cpu": "x64" }, "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.13", "", { "os": "win32", "cpu": "x64" }, "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-logs-otlp-proto": ["@opentelemetry/exporter-logs-otlp-proto@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.218.0", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-proto": ["@opentelemetry/exporter-metrics-otlp-proto@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/exporter-metrics-otlp-http": "0.218.0", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-proto": ["@opentelemetry/exporter-trace-otlp-proto@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.218.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.7.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.7.1", "@opentelemetry/core": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@types/bun": ["@types/bun@1.2.19", "", { "dependencies": { "bun-types": "1.2.19" } }, "sha512-d9ZCmrH3CJ2uYKXQIUuZ/pUnTqIvLDS0SK7pFmbx8ma+ziH/FRMoAq5bYpRG7y+w1gl+HgyNZbtqgMq4W4e2Lg=="],
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,16 @@
     "typescript": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.218.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.218.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.218.0",
+    "@opentelemetry/resources": "^2.7.1",
+    "@opentelemetry/sdk-logs": "^0.218.0",
+    "@opentelemetry/sdk-metrics": "^2.7.1",
+    "@opentelemetry/sdk-trace-node": "^2.7.1",
+    "@opentelemetry/semantic-conventions": "^1.41.1",
     "@typescript/native-preview": "^7.0.0-dev.20250822.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,37 @@
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import { SeverityNumber } from "@opentelemetry/api-logs";
+import { meter, otelLogger, shutdownTelemetry, withSpan } from "./telemetry";
+
+// url.full span attributes must not carry userinfo credentials (OTel semconv)
+function sanitizeUrl(url: string): string {
+	try {
+		const u = new URL(url);
+		u.username = "";
+		u.password = "";
+		return u.toString();
+	} catch {
+		return url;
+	}
+}
+
+// Metric instruments
+const httpRequestDuration = meter.createHistogram(
+	"reji_cleaner.http.client.duration",
+	{ description: "Duration of registry HTTP requests", unit: "ms" },
+);
+const manifestsDeletedCounter = meter.createCounter(
+	"reji_cleaner.manifests.deleted",
+	{ description: "Number of manifests deleted (or would be in dry-run)" },
+);
+const manifestsKeptCounter = meter.createCounter(
+	"reji_cleaner.manifests.kept",
+	{ description: "Number of manifests kept" },
+);
+const repositoriesProcessedCounter = meter.createCounter(
+	"reji_cleaner.repositories.processed",
+	{ description: "Number of repositories processed" },
+);
+
 // Configuration interface
 interface Config {
 	registryUrl: string;
@@ -132,6 +166,19 @@ class DockerRegistryClient {
 		const color = levelColors[level];
 		const levelText = level.toUpperCase().padEnd(7);
 		console.log(`${color}[${levelText}]${colors.reset} ${message}`);
+
+		const severities = {
+			info: SeverityNumber.INFO,
+			warn: SeverityNumber.WARN,
+			error: SeverityNumber.ERROR,
+			success: SeverityNumber.INFO,
+		};
+		otelLogger.emit({
+			severityNumber: severities[level],
+			severityText: level.toUpperCase(),
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: strip ANSI color codes from telemetry
+			body: message.replace(/\x1b\[[0-9;]*m/g, ""),
+		});
 	}
 
 	private getHeaders(additionalHeaders?: HeadersInit): HeadersInit {
@@ -151,9 +198,39 @@ class DockerRegistryClient {
 		return headers;
 	}
 
+	// fetch wrapper that records a client span and request duration metric
+	private async otelFetch(url: string, init?: RequestInit): Promise<Response> {
+		const method = init?.method || "GET";
+		return withSpan(
+			`HTTP ${method}`,
+			{
+				kind: SpanKind.CLIENT,
+				attributes: {
+					"http.request.method": method,
+					"url.full": sanitizeUrl(url),
+				},
+			},
+			async (span) => {
+				const start = performance.now();
+				try {
+					const response = await fetch(url, init);
+					span.setAttribute("http.response.status_code", response.status);
+					if (response.status >= 400) {
+						span.setStatus({ code: SpanStatusCode.ERROR });
+					}
+					return response;
+				} finally {
+					httpRequestDuration.record(performance.now() - start, {
+						"http.request.method": method,
+					});
+				}
+			},
+		);
+	}
+
 	async checkAPI(): Promise<boolean> {
 		try {
-			const response = await fetch(`${this.config.registryUrl}/v2/`, {
+			const response = await this.otelFetch(`${this.config.registryUrl}/v2/`, {
 				headers: this.getHeaders(),
 			});
 			return response.ok;
@@ -169,9 +246,12 @@ class DockerRegistryClient {
 		}
 
 		try {
-			const response = await fetch(`${this.config.registryUrl}/v2/_catalog`, {
-				headers: this.getHeaders(),
-			});
+			const response = await this.otelFetch(
+				`${this.config.registryUrl}/v2/_catalog`,
+				{
+					headers: this.getHeaders(),
+				},
+			);
 			if (!response.ok) {
 				throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 			}
@@ -185,7 +265,7 @@ class DockerRegistryClient {
 
 	async getTags(repository: string): Promise<string[]> {
 		try {
-			const response = await fetch(
+			const response = await this.otelFetch(
 				`${this.config.registryUrl}/v2/${repository}/tags/list`,
 				{
 					headers: this.getHeaders(),
@@ -207,7 +287,7 @@ class DockerRegistryClient {
 		reference: string,
 	): Promise<string | null> {
 		try {
-			const response = await fetch(
+			const response = await this.otelFetch(
 				`${this.config.registryUrl}/v2/${repository}/manifests/${reference}`,
 				{
 					method: "HEAD",
@@ -233,7 +313,7 @@ class DockerRegistryClient {
 		reference: string,
 	): Promise<DockerManifest | null> {
 		try {
-			const response = await fetch(
+			const response = await this.otelFetch(
 				`${this.config.registryUrl}/v2/${repository}/manifests/${reference}`,
 				{
 					headers: this.getHeaders(),
@@ -257,7 +337,7 @@ class DockerRegistryClient {
 		digest: string,
 	): Promise<DockerConfig | null> {
 		try {
-			const response = await fetch(
+			const response = await this.otelFetch(
 				`${this.config.registryUrl}/v2/${repository}/blobs/${digest}`,
 				{
 					headers: this.getHeaders(),
@@ -281,7 +361,7 @@ class DockerRegistryClient {
 		digest: string,
 	): Promise<ReferrersResponse | null> {
 		try {
-			const response = await fetch(
+			const response = await this.otelFetch(
 				`${this.config.registryUrl}/v2/${repository}/referrers/${digest}`,
 				{
 					headers: this.getHeaders(),
@@ -316,7 +396,7 @@ class DockerRegistryClient {
 			if (!attestationManifest) return null;
 
 			// Fetch the attestation blob
-			const response = await fetch(
+			const response = await this.otelFetch(
 				`${this.config.registryUrl}/v2/${repository}/blobs/${attestationManifest.digest}`,
 				{
 					headers: this.getHeaders(),
@@ -449,7 +529,7 @@ class DockerRegistryClient {
 
 		try {
 			this.log("info", `Deleting manifest: ${repository}@${digest}`);
-			const response = await fetch(
+			const response = await this.otelFetch(
 				`${this.config.registryUrl}/v2/${repository}/manifests/${digest}`,
 				{
 					method: "DELETE",
@@ -470,6 +550,29 @@ class DockerRegistryClient {
 	}
 
 	async processRepository(
+		repository: string,
+	): Promise<{ deleted: number; kept: number }> {
+		return withSpan(
+			"processRepository",
+			{ attributes: { "reji_cleaner.repository": repository } },
+			async (span) => {
+				const result = await this.processRepositoryInner(repository);
+				span.setAttributes({
+					"reji_cleaner.manifests.deleted": result.deleted,
+					"reji_cleaner.manifests.kept": result.kept,
+				});
+				repositoriesProcessedCounter.add(1);
+				manifestsDeletedCounter.add(result.deleted, {
+					repository,
+					dry_run: String(this.config.dryRun),
+				});
+				manifestsKeptCounter.add(result.kept, { repository });
+				return result;
+			},
+		);
+	}
+
+	private async processRepositoryInner(
 		repository: string,
 	): Promise<{ deleted: number; kept: number }> {
 		this.log(
@@ -634,11 +737,24 @@ class DockerRegistryClient {
 	}
 
 	async cleanup(): Promise<void> {
+		return withSpan(
+			"cleanup",
+			{
+				attributes: {
+					"reji_cleaner.registry_url": sanitizeUrl(this.config.registryUrl),
+					"reji_cleaner.dry_run": this.config.dryRun,
+				},
+			},
+			() => this.cleanupInner(),
+		);
+	}
+
+	private async cleanupInner(): Promise<void> {
 		this.log("info", "=".repeat(60));
 		this.log("info", "Docker Registry Cleanup Script");
 		this.log(
 			"info",
-			`Registry URL: ${colors.cyan}${this.config.registryUrl}${colors.reset}`,
+			`Registry URL: ${colors.cyan}${sanitizeUrl(this.config.registryUrl)}${colors.reset}`,
 		);
 		this.log(
 			"info",
@@ -653,7 +769,8 @@ class DockerRegistryClient {
 		// Check API connection
 		if (!(await this.checkAPI())) {
 			this.log("error", "Failed to connect to Docker Registry API");
-			process.exit(1);
+			// Throw instead of process.exit so pending telemetry can be flushed
+			throw new Error("Failed to connect to Docker Registry API");
 		}
 
 		// Get repository list
@@ -728,7 +845,10 @@ async function main() {
 			`${colors.red}[ERROR]${colors.reset} Unexpected error:`,
 			error,
 		);
-		process.exit(1);
+		process.exitCode = 1;
+	} finally {
+		// Flush traces/metrics/logs before the short-lived process exits
+		await shutdownTelemetry();
 	}
 }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,112 @@
+import {
+	type Meter,
+	metrics,
+	type Span,
+	type SpanOptions,
+	SpanStatusCode,
+	type Tracer,
+	trace,
+} from "@opentelemetry/api";
+import { type Logger, logs } from "@opentelemetry/api-logs";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import {
+	defaultResource,
+	resourceFromAttributes,
+} from "@opentelemetry/resources";
+import {
+	BatchLogRecordProcessor,
+	LoggerProvider,
+} from "@opentelemetry/sdk-logs";
+import {
+	MeterProvider,
+	PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics";
+import {
+	BatchSpanProcessor,
+	NodeTracerProvider,
+} from "@opentelemetry/sdk-trace-node";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+
+const SERVICE_NAME = Bun.env.OTEL_SERVICE_NAME || "reji-cleaner";
+
+// Without an explicit endpoint the exporters would silently retry against
+// the default http://localhost:4318 and delay process exit by ~10s, so
+// telemetry stays disabled (no-op providers) unless one is configured.
+const telemetryEnabled = Boolean(
+	Bun.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
+		Bun.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
+		Bun.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT ||
+		Bun.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+);
+
+let tracerProvider: NodeTracerProvider | undefined;
+let meterProvider: MeterProvider | undefined;
+let loggerProvider: LoggerProvider | undefined;
+
+if (telemetryEnabled) {
+	// OTLP exporters read OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_HEADERS
+	// from the environment automatically; only the resource is configured here.
+	const resource = defaultResource().merge(
+		resourceFromAttributes({ [ATTR_SERVICE_NAME]: SERVICE_NAME }),
+	);
+
+	tracerProvider = new NodeTracerProvider({
+		resource,
+		spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter())],
+	});
+	tracerProvider.register();
+
+	meterProvider = new MeterProvider({
+		resource,
+		readers: [
+			new PeriodicExportingMetricReader({
+				exporter: new OTLPMetricExporter(),
+				exportIntervalMillis: Number.parseInt(
+					Bun.env.OTEL_METRIC_EXPORT_INTERVAL || "60000",
+					10,
+				),
+			}),
+		],
+	});
+	metrics.setGlobalMeterProvider(meterProvider);
+
+	loggerProvider = new LoggerProvider({
+		resource,
+		processors: [new BatchLogRecordProcessor(new OTLPLogExporter())],
+	});
+	logs.setGlobalLoggerProvider(loggerProvider);
+}
+
+export const tracer: Tracer = trace.getTracer(SERVICE_NAME);
+export const meter: Meter = metrics.getMeter(SERVICE_NAME);
+export const otelLogger: Logger = logs.getLogger(SERVICE_NAME);
+
+// Run fn inside an active span, recording failures on it and always ending it
+export async function withSpan<T>(
+	name: string,
+	options: SpanOptions,
+	fn: (span: Span) => Promise<T>,
+): Promise<T> {
+	return tracer.startActiveSpan(name, options, async (span) => {
+		try {
+			return await fn(span);
+		} catch (error) {
+			span.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
+			throw error;
+		} finally {
+			span.end();
+		}
+	});
+}
+
+// Flush pending telemetry before the process exits (required for a
+// short-lived CLI; batch processors hold data in memory otherwise).
+export async function shutdownTelemetry(): Promise<void> {
+	await Promise.allSettled([
+		tracerProvider?.shutdown(),
+		meterProvider?.shutdown(),
+		loggerProvider?.shutdown(),
+	]);
+}


### PR DESCRIPTION
## Summary

- OpenTelemetry計装を追加し、traces / logs / metrics をOTLP (http/protobuf) で送信できるようにした
- `src/telemetry.ts` を新設: `OTEL_EXPORTER_OTLP_*ENDPOINT` が設定されているときだけexporterを初期化(未設定時はno-opで、コレクタ不在環境での無音リトライと約10秒の終了遅延を回避)
- registryへの全HTTPリクエストをCLIENT span + duration histogramで記録
- `cleanup` / `processRepository` にspanとカウンタ(`manifests.deleted` / `manifests.kept` / `repositories.processed`)を追加
- 既存のコンソールログをOTel Logsにも送信(ANSIカラーコード除去)
- URLのuserinfo認証情報をテレメトリ記録前に除去
- flush保証のため `process.exit(1)` をthrow + `process.exitCode = 1` に変更(終了コードは従来どおり)

## Test plan

- [x] `bun run lint` 通過、src配下に型エラーなし
- [x] localクラスタのotel-gateway経由でGreptimeDBに3シグナル(traces/metrics/logs)が到達することをe2e確認
- [x] userinfo付きURL (`http://user:secret@...`) がspan属性・ログ本文から除去されることを確認
- [x] OTLPエンドポイント未設定時は計装がno-opとなり、即時終了(0.3秒)することを確認