### PR TITLE
fix(telemetry): treat referrers API 404 as non-error span

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,11 @@ class DockerRegistryClient {
 	}
 
 	// fetch wrapper that records a client span and request duration metric
-	private async otelFetch(url: string, init?: RequestInit): Promise<Response> {
+	private async otelFetch(
+		url: string,
+		init?: RequestInit,
+		options?: { expectedStatuses?: number[] },
+	): Promise<Response> {
 		const method = init?.method || "GET";
 		return withSpan(
 			`HTTP ${method}`,
@@ -215,7 +219,10 @@ class DockerRegistryClient {
 				try {
 					const response = await fetch(url, init);
 					span.setAttribute("http.response.status_code", response.status);
-					if (response.status >= 400) {
+					if (
+						response.status >= 400 &&
+						!options?.expectedStatuses?.includes(response.status)
+					) {
 						span.setStatus({ code: SpanStatusCode.ERROR });
 					}
 					return response;
@@ -366,6 +373,9 @@ class DockerRegistryClient {
 				{
 					headers: this.getHeaders(),
 				},
+				// 404 means no referrers exist for this manifest, which is normal per
+				// OCI dist-spec 1.1 — don't surface it as an error span.
+				{ expectedStatuses: [404] },
 			);
 			if (!response.ok) {
 				return null;


### PR DESCRIPTION
## Summary
- OCI Distribution Spec 1.1 の `/v2/<repo>/referrers/<digest>` は、対象 manifest を参照するアーティファクト（attestation, SBOM 等）が存在しない場合 404 を返すのが正常動作。これがエラー span として記録されてしまっていたのを修正
- `otelFetch` に `expectedStatuses` オプションを追加し、許可ステータスはエラー span にしないようにした
- `getReferrers` の呼び出しで `{ expectedStatuses: [404] }` を指定

trace `e50e0223f8f483bae6cfbc520c346673` に含まれていた 4件の "HTTP GET" エラー span はすべてこのケースで、本変更で解消される。

## Test plan
- [x] `bun build` でビルド成功を確認
- [ ] 実行時に referrers API が 404 を返すケースで、span が ERROR にならないことを後続のトレースで確認

https://claude.ai/code/session_019KWnU3B6d8ir2roRCR6FD7